### PR TITLE
gracefully shutdown server when running in the container

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const { readFile } = require('fs');
 const { extname } = require('path');
 
+const shutdown = require('./shtudown');
 const render = require('./renderer');
 const h = require('./renderer/h');
 const home = require('./pages/home');
@@ -36,8 +37,10 @@ function sendResponse(stream, head, body) {
   stream.end();
 }
 
-createServer(app).listen(process.env.PORT, () =>
-  console.log(`http://localhost:${process.env.PORT}`)
+shutdown(
+  createServer(app).listen(process.env.PORT, () =>
+    console.log(`http://localhost:${process.env.PORT}`)
+  )
 );
 
 app.use(

--- a/server/shtudown.js
+++ b/server/shtudown.js
@@ -1,0 +1,24 @@
+// Taken from https://medium.com/@becintec/building-graceful-node-applications-in-docker-4d2cd4d5d392
+
+const signals = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGTERM: 15,
+};
+
+module.exports = function(server) {
+  function shutdown(signal, value) {
+    console.log('shutdown!');
+    server.close(() => {
+      console.log(`server stopped by ${signal} with value ${value}`);
+      process.exit(128 + value);
+    });
+  }
+
+  Object.keys(signals).forEach(signal => {
+    process.on(signal, () => {
+      console.log(`process received a ${signal} signal`);
+      shutdown(signal, signals[signal]);
+    });
+  });
+};


### PR DESCRIPTION
Today when running the container in the foreground and attempting to `ctrl+c` the input is essentially ignored and the server continues to run. This change will allow the node process to receive and gracefully shut http server down.

The actual code was taken from https://medium.com/@becintec/building-graceful-node-applications-in-docker-4d2cd4d5d392