### PR TITLE
custom elements

### DIFF
--- a/server/pages/home.js
+++ b/server/pages/home.js
@@ -11,9 +11,10 @@ function nameToHuman(name) {
 
 function candidate([name, data]) {
   return h(
-    'div',
+    'candidate-card',
     {
       class: `candidate ${data.suspended ? 'suspended' : ''}`,
+      name: name,
     },
     h('img', {
       class: 'candidate-image',


### PR DESCRIPTION
This may be a terrible idea, but we could swap the current `div` elements to `candidate-card` elements as an incremental step to using custom elements. This proves the fallback to usable HTML is in place.

See, still renders fine!
<img width="916" alt="Screen Shot 2020-02-14 at 7 25 59 PM" src="https://user-images.githubusercontent.com/1883231/74581069-e2931980-4f5f-11ea-9844-18e908bcc7aa.png">
