### PR TITLE
Husky instead of predev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "build:client": "webpack -p",
     "dev:client": "webpack --watch --mode=development",
     "dev:server": "NODE_ENV=dev nodemon -w ./ -e css,js,json,html ./server/index.js",
-    "predev": "cmp -s package.json ._package.json || (npm install && cp package.json ._package.json)",
     "dev": "npm-run-all -p dev:*",
     "lint:client": "eslint --ext .ts client"
   },
@@ -51,7 +50,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "post-merge": "bash -c 'echo \"$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)\" | grep --quiet \"package.json\" && eval \"npm install\"'"
     }
   }
 }


### PR DESCRIPTION
Use husky post-merge to check if package.json changed, do npm install there instead of relying on creating transient files.﻿
